### PR TITLE
Adding 'Auto Z-Align' macro

### DIFF
--- a/klipper-printer-sovol-sv06.cfg
+++ b/klipper-printer-sovol-sv06.cfg
@@ -74,7 +74,7 @@ microsteps: 16
 rotation_distance: 4
 endstop_pin: probe:z_virtual_endstop
 position_min: -4
-position_max: 261
+position_max: 262
 homing_speed: 4
 
 [tmc2209 stepper_z]
@@ -164,3 +164,21 @@ sclk_pin: PB13
 sid_pin: PB15
 encoder_pins: ^PB14, ^PB10
 click_pin: ^!PB2
+
+[gcode_macro MECHANICAL_GANTRY_CALIBRATION]
+gcode:
+    SAVE_GCODE_STATE NAME=MG_state
+	{% set oldcurrent = printer.configfile.settings["tmc2209 stepper_z"].run_current %} ; TODO: Find runtime current settings
+    {% if printer.toolhead.homed_axes != "xyz" %}
+      G28
+    {% endif %}
+	G90
+	G0 Z251 F1500 ; go to the Z-max at speed 12*60
+	SET_TMC_CURRENT STEPPER=stepper_z CURRENT=0.3
+	G4 P200 ; Probably not necessary, it is here just for sure
+    G0 Z262 F500
+	SET_TMC_CURRENT STEPPER=stepper_z CURRENT={oldcurrent}
+	G4 P200 ; same as the first one
+    G0 Z251 F1500
+    RESTORE_GCODE_STATE NAME=MG_state
+	G28


### PR DESCRIPTION
This Klipper macro mimics the factory Marlin code for "Auto Z-Align".